### PR TITLE
Update client.css popup tablist margin issue

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -452,7 +452,7 @@ button:disabled {
 	padding: 3px 0 4px 0;
 }
 .tablist li {
-	margin: 0 -5px -1px -5px;
+	margin: 0 -1px;
 	padding: 0;
 }
 .tablist .button {


### PR DESCRIPTION
margin value shouldn't be -5px as you can see with this visual bug seen on mobile
providing fix
before: http://prntscr.com/pja63m
after: http://prntscr.com/pja5rk